### PR TITLE
Update profile READMEs: simplify bio and fix links

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -5,28 +5,18 @@
 ## `$ whoami`
 
 2025/04 から ? でエンジニアをしています。  
-現在, Golang, Infra (Architecture), Android に興味があり勉強をしています。
+Web 開発と開発者ツールに興味があります。
 
 - 職務経歴書 ([en](./aboutme/work_experience_en.md) / [ja](./aboutme/work_experience.md))
 - [履歴書](./aboutme/resume.md)
 - [私についての補足情報](./aboutme/README.ja.md)
-
-### スキル
-
-**Advanced:**  
-育成中。
-
-**Intermediate:**  
-<img alt="my skills" src="https://skillicons.dev/icons?theme=light&perline=8&i=kotlin,androidstudio,go,aws,python,bash,git,github,githubactions" />
-
-**Beginner:**  
-<img alt="my skills" src="https://skillicons.dev/icons?theme=light&perline=8&i=swift,flutter,ts,js,html,css,vue,firebase,rails,linux,terraform,jenkins" />
 
 ### Links
 
 - [Zenn](https://zenn.dev/kokoichi206)
 - [GitHub Gist](https://gist.github.com/kokoichi206)
 - [はてなブログ](https://koko206.hatenablog.com/archive)
+- [LAPRAS](https://lapras.com/public/SYU7UNS)
 
 ### SNS
 

--- a/README.md
+++ b/README.md
@@ -5,24 +5,11 @@
 ## `$ whoami`
 
 Web engineer at ? since 2025/04.  
-I'm currently learning
-
-[![Typing SVG](https://readme-typing-svg.demolab.com?font=Cosmic&size=22&duration=1200&pause=100&color=25AC3C&center=true&vCenter=true&multiline=true&repeat=false&width=435&height=70&lines=Web+App+Development;Computer+Science)](https://git.io/typing-svg)
+Interested in Web Development and Developer Tooling.
 
 - Work Experience ([en](./aboutme/work_experience_en.md) / [ja](./aboutme/work_experience.md))
 - [Resume (ja)](./aboutme/resume.md)
 - [about me](./aboutme/)
-
-### Skills
-
-**Advanced:**  
-Now I'm searching...
-
-**Intermediate:**  
-<img alt="my skills" src="https://skillicons.dev/icons?theme=light&perline=8&i=go,aws,gcp,elasticsearch,kotlin,androidstudio,python,bash,git,github,githubactions" />
-
-**Beginner:**  
-<img alt="my skills" src="https://skillicons.dev/icons?theme=light&perline=8&i=ts,js,html,css,nextjs,react,vue,firebase,swift,flutter,rails,linux,terraform,jenkins" />
 
 ### Links
 
@@ -42,7 +29,7 @@ Now I'm searching...
   - Mainly About GitLab CI/CD
 - [AtCoder](https://atcoder.jp/users/kokoichi26)
 - [Kaggle](https://www.kaggle.com/kokoichi)
-- [Qiita](https://img.shields.io/badge/Qiita-55c500.svg?&style=flat-square&logo=qiita&logoColor=white)
+- [Qiita](https://qiita.com/kokoichi26)
 
 ### Activities ✨
 


### PR DESCRIPTION
## Summary
- プロフィールの興味分野を Web Development / Developer Tooling に更新
- Skills セクション（Advanced/Intermediate/Beginner）を両 README から削除
- 日本語 README に LAPRAS リンクを追加
- Qiita リンクを修正（バッジ画像 URL → 実際のプロフィール URL）

## Test plan
- [ ] README.md のレンダリングを GitHub 上で確認
- [ ] README.ja.md のレンダリングを GitHub 上で確認
- [ ] 各リンクが正しく機能することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)